### PR TITLE
Bug fix: single amino acid at position 4 crashes polymerization

### DIFF
--- a/UserInterface.py
+++ b/UserInterface.py
@@ -962,11 +962,14 @@ e.g. β-Asp, Ala>Ala, Ser>Ala>Thr>Ala
         AAs = self.gen_retrieve_AAs(idx=[4, 5])
         if self.generator.modifications["Alanine/Lactate Substitution"]:
             AAs.append("Lac")  # add Lactate if modification used
-        AA_lst = easygui.multchoicebox(
-            self.history+msg,
-            self.title,
-            choices=AAs,
-            preselect=preselect)
+        if len(AAs) == 1:
+            AA_lst = AAs
+        else:
+            AA_lst = easygui.multchoicebox(
+                self.history+msg,
+                self.title,
+                choices=AAs,
+                preselect=preselect)
         if AA_lst is None:
             self.history = f"{name} polymerisation not added - no AAs provided."
             return preselect
@@ -1032,11 +1035,14 @@ e.g. β-Asp, Ala>Ala, Ser>Ala>Thr>Ala
         AAs = self.gen_retrieve_AAs(idx=[4, 5])
         if self.generator.modifications["Alanine/Lactate Substitution"]:
             AAs.append("Lac")  # add Lactate if modification used
-        AA_lst = easygui.multchoicebox(
-            self.history+msg,
-            self.title,
-            choices=AAs,
-            preselect=preselect)
+        if len(AAs) == 1:
+            AA_lst = AAs
+        else:
+            AA_lst = easygui.multchoicebox(
+                self.history+msg,
+                self.title,
+                choices=AAs,
+                preselect=preselect)
         if AA_lst is None:
             self.history = f"{name} polymerisation not added - no AAs provided."
             return preselect


### PR DESCRIPTION
I have noticed a bug while using the user interface to generate PGNs.

Selecting any of the polymerization choices (besides "No polymerization") when a single amino acid has been picked at position 4 (e.g, Ala) makes the program raise an exception. 

The issue comes from the use `easygui.multchoicebox`, which expects two choices at least.

Fix: check length of AAs list before calling `easygui.multchoicebox`. If the length is 1, no need to ask. After applying the change I am able to generate polymerizations without issue.

Hope this helps. Fantastic paper by the way!
